### PR TITLE
Add support for output format when POSTing bundle yaml directly

### DIFF
--- a/api.py
+++ b/api.py
@@ -94,7 +94,7 @@ def process_bundle(bundle):
         #algo = getattr(nx, layout + '_layout', None)
         layout(bundle, nx.circular_layout)
 
-    with tempfile.NamedTemporaryFile() as f:
+    with tempfile.NamedTemporaryFile(mode='w') as f:
         f.write(yaml.dump(bundle, default_flow_style=False))
         f.flush()
         try:


### PR DESCRIPTION
Also includes a fix for `TypeError: a bytes-like object is required, not 'str'` that I ran in to while testing.